### PR TITLE
[rest] Changes after review: java set to 1.7, groupId modified in pom.xml

### DIFF
--- a/rest/server/alfa/pom.xml
+++ b/rest/server/alfa/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ro.gov.ithub</groupId>
+    <groupId>ro.gov.ithub.infotranspub</groupId>
     <artifactId>alfa</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
     </properties>
 
     <parent>


### PR DESCRIPTION
- java version 1.7, because ICI uses OpenJDK 1.7
- to avoid conflicts with other repo projects, all info_trans_pub projects have the reverse DNS groupId "ro.gov.ithub.infotranspub"